### PR TITLE
Added in trivial read of first few ADC samples

### DIFF
--- a/software/app/main_bin.c
+++ b/software/app/main_bin.c
@@ -306,12 +306,6 @@ result_t go()
     dbprintf("ADC samples per packet: %d\n", adc.regs->samples_per_packet);
 
     /*
-     * Read the first sample from the ADC and ignore it - the ADC always has an
-     * invalid measurement as the first reading.
-     */
-    AbortIfNot(record(&dma, samples, adc.regs->samples_per_packet, adc), fail);
-
-    /*
      * Bind the command port, data stream port, and the result output port.
      */
     udp_socket_t command_socket, data_stream_socket, result_socket, xcorr_stream_socket, silent_request_socket;
@@ -338,6 +332,12 @@ result_t go()
             ticks_to_ms(get_system_time()));
 
     set_interrupts(true);
+
+    /*
+     * Read the first sample from the ADC and ignore it - the ADC always has an
+     * invalid measurement as the first reading.
+     */
+    AbortIfNot(record(&dma, samples, adc.regs->samples_per_packet, adc), fail);
 
     /*
      * Set up the initial parameters.

--- a/software/app/main_bin.c
+++ b/software/app/main_bin.c
@@ -306,6 +306,12 @@ result_t go()
     dbprintf("ADC samples per packet: %d\n", adc.regs->samples_per_packet);
 
     /*
+     * Read the first sample from the ADC and ignore it - the ADC always has an
+     * invalid measurement as the first reading.
+     */
+    AbortIfNot(record(&dma, samples, adc.regs->samples_per_packet, adc), fail);
+
+    /*
      * Bind the command port, data stream port, and the result output port.
      */
     udp_socket_t command_socket, data_stream_socket, result_socket, xcorr_stream_socket, silent_request_socket;


### PR DESCRIPTION
This causes the first sample of the ADC to be ignored and prevents a bug that causes ping detection upon initial boot. Addresses https://github.com/PalouseRobosub/hydro-zynq/issues/4